### PR TITLE
feat: add show-sprint command — single command for colored sprint dis…

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ node azdev-tools.cjs create-branch --repo <path> --story-id <id> --title <title>
 
 # Push and create PR
 node azdev-tools.cjs create-pr --repo <path> --branch <name> --base <branch> --title <title> --body <body>
+
+# Display sprint board (fetch + render in one command)
+node azdev-tools.cjs show-sprint [--me] --cwd <path>
 ```
 
 All commands output JSON to stdout and use exit code 0/1 for success/failure.

--- a/bin/azdev-tools.cjs
+++ b/bin/azdev-tools.cjs
@@ -75,6 +75,13 @@
  *     Pushes the branch to origin and creates a pull request using the gh CLI.
  *     stdout: JSON {"pr":"<url>","branch":"...","base":"...","pushed":true}
  *     Exit 0 on success, exit 1 on error.
+ *
+ *   show-sprint [--me] [--cwd <path>]
+ *     Fetches sprint data and renders a colored board to stdout using ANSI codes.
+ *     Combines get-sprint + get-sprint-items + rendering in a single command.
+ *     --me: Filter to items assigned to the authenticated user.
+ *     stdout: ANSI-colored sprint board text
+ *     Exit 0 on success, exit 1 on error.
  */
 
 'use strict';
@@ -938,6 +945,245 @@ async function cmdGetChildStates(cwd, args) {
   }
 }
 
+// ─── Sprint Rendering ───────────────────────────────────────────────────────────
+
+/**
+ * Renders a sprint board with ANSI colors given sprint metadata and items.
+ * Pure rendering function — no I/O, returns array of lines.
+ * @param {object} sprint - Sprint metadata (name, path, startDate, finishDate)
+ * @param {Array} items - Work items array from get-sprint-items
+ * @returns {string[]} Lines of ANSI-colored output
+ */
+function renderSprintBoard(sprint, items) {
+  const RESET = '\x1b[0m';
+  const BOLD = '\x1b[1m';
+  const DIM = '\x1b[2m';
+  const WHITE = '\x1b[37m';
+  const CYAN = '\x1b[36m';
+  const BLUE = '\x1b[34m';
+  const GREEN = '\x1b[32m';
+  const RED = '\x1b[31m';
+  const YELLOW = '\x1b[33m';
+  const MAGENTA = '\x1b[35m';
+
+  function stateColor(state) {
+    switch (state) {
+      case 'New': return WHITE;
+      case 'Active': return BLUE;
+      case 'Resolved': return GREEN;
+      case 'Closed': case 'Done': return GREEN + BOLD;
+      case 'Removed': return RED;
+      default: return YELLOW;
+    }
+  }
+
+  function stateLabel(state) {
+    switch (state) {
+      case 'Closed': case 'Done': return 'DONE';
+      default: return state ? state.toUpperCase() : 'UNKNOWN';
+    }
+  }
+
+  function typeAbbrev(type) {
+    if (type === 'User Story') return 'US';
+    return type || 'Item';
+  }
+
+  function formatDate(d) {
+    if (!d) return 'not set';
+    return String(d).slice(0, 10);
+  }
+
+  // Use the module-level stripHtml for description/AC fields
+  const lines = [];
+  const push = (l) => lines.push(l);
+
+  // Sprint header
+  push('');
+  push(`${BOLD}${CYAN}━━━ Sprint: ${sprint.name || 'Unknown'} ━━━${RESET}`);
+  push(`${DIM}Iteration:${RESET} ${sprint.path || 'N/A'}`);
+  push(`${DIM}Dates:${RESET}     ${formatDate(sprint.startDate)} → ${formatDate(sprint.finishDate)}`);
+  push(`${DIM}Items:${RESET}     ${items.length}`);
+  push('');
+
+  if (items.length === 0) {
+    push('No work items in this sprint.');
+    return lines;
+  }
+
+  // Build parent-child grouping
+  const itemMap = new Map();
+  items.forEach(item => itemMap.set(item.id, item));
+
+  const topLevel = [];
+  const childrenOf = new Map();
+
+  items.forEach(item => {
+    if (item.parentId && itemMap.has(item.parentId)) {
+      if (!childrenOf.has(item.parentId)) childrenOf.set(item.parentId, []);
+      childrenOf.get(item.parentId).push(item);
+    } else {
+      topLevel.push(item);
+    }
+  });
+
+  for (const story of topLevel) {
+    const sc = stateColor(story.state);
+    const abbrev = typeAbbrev(story.type);
+    const assigned = story.assignedTo || 'Unassigned';
+
+    push(`${BOLD}┌─ [${abbrev}] #${story.id} — ${story.title}${RESET}`);
+    push(`│  State: ${sc}${stateLabel(story.state)}${RESET}  │  Assigned: ${assigned}`);
+
+    // Description (first 3 lines) — items already have HTML stripped by get-sprint-items
+    const desc = story.description || '';
+    if (desc) {
+      const descLines = desc.split('\n').filter(l => l.trim()).slice(0, 3);
+      for (const dl of descLines) {
+        push(`│  ${DIM}${dl}${RESET}`);
+      }
+    } else {
+      push(`│  ${DIM}(no description)${RESET}`);
+    }
+
+    // Acceptance criteria
+    const ac = story.acceptanceCriteria || '';
+    if (ac) {
+      push('│');
+      push(`│  ${MAGENTA}Acceptance Criteria:${RESET}`);
+      const acLines = ac.split('\n').filter(l => l.trim());
+      for (const al of acLines) {
+        push(`│  ${DIM}${al}${RESET}`);
+      }
+    } else {
+      push('│');
+      push(`│  ${MAGENTA}Acceptance Criteria:${RESET}`);
+      push(`│  ${DIM}(no acceptance criteria)${RESET}`);
+    }
+
+    // Child tasks
+    const children = childrenOf.get(story.id) || [];
+    if (children.length > 0) {
+      push('│');
+      for (const child of children) {
+        const cc = stateColor(child.state);
+        const ca = child.assignedTo || 'Unassigned';
+        push(`│   ${cc}■${RESET} #${child.id} — ${child.title}  [${cc}${stateLabel(child.state)}${RESET}]  ${ca}`);
+      }
+    }
+
+    push('└──────');
+    push('');
+  }
+
+  return lines;
+}
+
+/**
+ * Handles the show-sprint command.
+ * Fetches sprint metadata and items from Azure DevOps, then renders
+ * a colored terminal board. Single command — no intermediate JSON passing needed.
+ *
+ * Usage: azdev-tools.cjs show-sprint [--me] [--cwd <path>]
+ *
+ * stdout: ANSI-colored sprint board
+ * Exit 0 on success, exit 1 on error.
+ *
+ * @param {string} cwd - Working directory
+ * @param {string[]} args - CLI args (supports --me)
+ */
+async function cmdShowSprint(cwd, args) {
+  const mine = args && args.includes('--me');
+
+  try {
+    const { cfg, encodedPat, teamName, iteration } = await getSprintData(cwd);
+
+    // Build sprint metadata
+    const sprint = {
+      name: iteration.name,
+      path: iteration.path,
+      startDate: iteration.attributes ? iteration.attributes.startDate : null,
+      finishDate: iteration.attributes ? iteration.attributes.finishDate : null,
+    };
+
+    // Fetch work item IDs
+    const workItemsUrl = `${cfg.org}/${cfg.project}/${encodeURIComponent(teamName)}/_apis/work/teamsettings/iterations/${iteration.id}/workitems?api-version=7.1`;
+    const wiRes = await makeRequest(workItemsUrl, encodedPat);
+    if (wiRes.status !== 200) {
+      throw new Error(`Failed to fetch sprint work items: HTTP ${wiRes.status}`);
+    }
+
+    const wiData = JSON.parse(wiRes.body);
+    const idSet = new Set();
+    for (const rel of (wiData.workItemRelations || [])) {
+      if (rel.target) idSet.add(rel.target.id);
+      if (rel.source) idSet.add(rel.source.id);
+    }
+    const ids = Array.from(idSet);
+
+    if (ids.length === 0) {
+      const lines = renderSprintBoard(sprint, []);
+      process.stdout.write(lines.join('\n') + '\n');
+      process.exit(0);
+    }
+
+    let batchIds = ids;
+    if (ids.length > 200) {
+      console.error(`Warning: Sprint has ${ids.length} work items, showing first 200.`);
+      batchIds = ids.slice(0, 200);
+    }
+
+    // Batch fetch details
+    const batchUrl = `${cfg.org}/${cfg.project}/_apis/wit/workitemsbatch?api-version=7.1`;
+    const batchBody = {
+      ids: batchIds,
+      fields: [
+        'System.Id', 'System.Title', 'System.WorkItemType',
+        'System.State', 'System.Description',
+        'Microsoft.VSTS.Common.AcceptanceCriteria',
+        'System.Parent', 'System.AssignedTo',
+      ],
+      errorPolicy: 'omit',
+    };
+    const batchRes = await makeRequest(batchUrl, encodedPat, 'POST', batchBody);
+    if (batchRes.status !== 200) {
+      throw new Error(`Failed to batch fetch work item details: HTTP ${batchRes.status}`);
+    }
+
+    const batchData = JSON.parse(batchRes.body);
+    let items = (batchData.value || []).map((item) => {
+      const assignedTo = item.fields['System.AssignedTo'];
+      return {
+        id: item.id,
+        type: item.fields['System.WorkItemType'],
+        title: item.fields['System.Title'],
+        state: item.fields['System.State'],
+        description: stripHtml(item.fields['System.Description'] || ''),
+        acceptanceCriteria: stripHtml(item.fields['Microsoft.VSTS.Common.AcceptanceCriteria'] || ''),
+        parentId: item.fields['System.Parent'] || null,
+        assignedTo: assignedTo ? assignedTo.displayName : null,
+      };
+    });
+
+    // Filter to current user if --me
+    if (mine) {
+      const currentUser = await getAuthenticatedUser(cfg.org, encodedPat);
+      const myItemIds = new Set(items.filter(i => i.assignedTo === currentUser).map(i => i.id));
+      const myParentIds = new Set(items.filter(i => myItemIds.has(i.id) && i.parentId).map(i => i.parentId));
+      const myChildIds = new Set(items.filter(i => myItemIds.has(i.parentId)).map(i => i.id));
+      const allMyIds = new Set([...myItemIds, ...myParentIds, ...myChildIds]);
+      items = items.filter(i => allMyIds.has(i.id));
+    }
+
+    const lines = renderSprintBoard(sprint, items);
+    process.stdout.write(lines.join('\n') + '\n');
+    process.exit(0);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
 // ─── Git / PR Helpers ───────────────────────────────────────────────────────────
 
 /**
@@ -1220,6 +1466,10 @@ async function main() {
     console.error('  create-pr --repo <path> --branch <name> --base <branch> --title <title> --body <body>');
     console.error('               Push branch and create a PR using gh CLI');
     console.error('               stdout: JSON {pr: "<url>", branch, base, pushed: bool}');
+    console.error('');
+    console.error('  show-sprint [--me]');
+    console.error('               Fetch sprint data and render colored board to stdout');
+    console.error('               --me: filter to items assigned to the authenticated user');
     process.exit(1);
   }
 
@@ -1270,9 +1520,13 @@ async function main() {
       await cmdCreatePr(cwd, cmdArgs);
       break;
 
+    case 'show-sprint':
+      await cmdShowSprint(cwd, cmdArgs);
+      break;
+
     default:
       console.error(`Unknown command: ${command}`);
-      console.error('Available commands: save-config, load-config, test, get-sprint, get-sprint-items, get-branch-links, update-description, update-state, get-child-states, create-branch, create-pr');
+      console.error('Available commands: save-config, load-config, test, get-sprint, get-sprint-items, get-branch-links, update-description, update-state, get-child-states, create-branch, create-pr, show-sprint');
       process.exit(1);
   }
 }

--- a/commands/azdev-sprint.md
+++ b/commands/azdev-sprint.md
@@ -3,12 +3,11 @@ name: azdev-sprint
 description: View current sprint backlog from Azure DevOps
 argument-hint: ""
 allowed-tools:
-  - Read
   - Bash
 ---
 
 <objective>
-Fetch and display the current sprint backlog from Azure DevOps. Show sprint metadata (name, dates, iteration path) followed by work items grouped by parent story with tasks indented underneath. Output MUST use ANSI color codes via Bash for colored terminal output.
+Fetch and display the current sprint backlog from Azure DevOps with ANSI-colored terminal output. One command does everything — no intermediate steps needed.
 </objective>
 
 <execution_context>
@@ -19,132 +18,36 @@ Config file: .planning/azdev-config.json
 <context>
 $CWD is the project directory where .planning/ lives.
 
-azdev-tools.cjs CLI contracts:
+azdev-tools.cjs CLI contract used by this command:
 
-  node ~/.claude/bin/azdev-tools.cjs load-config --cwd $CWD
-    -> stdout: JSON {"org":"...","project":"...","pat":"<raw-decoded>"}
-    -> exit 0 on success, exit 1 if no config
-
-  node ~/.claude/bin/azdev-tools.cjs get-sprint --cwd $CWD
-    -> stdout: JSON {"iterationId":"...","name":"...","path":"...","startDate":"...","finishDate":"..."}
+  node ~/.claude/bin/azdev-tools.cjs show-sprint [--me] --cwd $CWD
+    -> Fetches sprint metadata, fetches work items, renders colored board to stdout
+    -> --me: filter to items assigned to the authenticated user
+    -> stdout: ANSI-colored sprint board (stories grouped with tasks, colored state indicators)
     -> exit 0 on success
-    -> exit 1 on error (stderr contains message — e.g., no active sprint, auth failure)
-
-  node ~/.claude/bin/azdev-tools.cjs get-sprint-items [--me] --cwd $CWD
-    -> stdout: JSON array [{"id":N,"type":"User Story"|"Task"|"Bug"|...,"title":"...","state":"...","description":"...","acceptanceCriteria":"...","parentId":N|null,"assignedTo":"Name"|null}]
-    -> --me: filter to items assigned to the authenticated user (includes parent stories of your tasks and child tasks of your stories)
-    -> exit 0 on success (empty sprint returns [])
-    -> exit 1 on error (stderr contains message)
+    -> exit 1 on error (stderr contains message — e.g., no config, no active sprint, auth failure)
 </context>
 
 <process>
-1. **Check prerequisites:**
-   - Verify `~/.claude/bin/azdev-tools.cjs` exists using the Read tool or Bash `test -f`.
-     If it does not exist: tell the user "Azure DevOps tools not installed. Check that ~/.claude/bin/azdev-tools.cjs exists." Stop.
-   - Run `node ~/.claude/bin/azdev-tools.cjs load-config --cwd $CWD`
-     If exit 1: tell the user "No Azure DevOps config found. Run `/azdev-setup` to configure your connection." Stop.
+1. **Check that the helper exists:**
+   Run: `test -f ~/.claude/bin/azdev-tools.cjs`
+   If missing: tell the user "Azure DevOps tools not installed. Check that ~/.claude/bin/azdev-tools.cjs exists." Stop.
 
-2. **Fetch sprint metadata:**
-   Run `node ~/.claude/bin/azdev-tools.cjs get-sprint --cwd $CWD`
-   - If exit 1: show the error message from stderr to the user. Stop.
-   - If exit 0: parse the JSON from stdout. Extract: name, path, startDate, finishDate.
+2. **Run the show-sprint command:**
+   Run: `node ~/.claude/bin/azdev-tools.cjs show-sprint --cwd $CWD`
+   That's it. The command handles everything: config loading, API calls, rendering.
 
-3. **Fetch sprint items:**
-   Run `node ~/.claude/bin/azdev-tools.cjs get-sprint-items --cwd $CWD`
-   - If exit 1: show the error message from stderr to the user. Stop.
-   - If exit 0: parse the JSON array from stdout.
-
-4. **Build and display colored output via Bash:**
-
-   IMPORTANT: All display output MUST be rendered using `echo -e` in a single Bash command. Do NOT output plain text directly — use Bash so the ANSI color codes are interpreted by the terminal.
-
-   Build a Bash script that uses `echo -e` to print the entire sprint board with ANSI colors. Use these color codes:
-
-   **ANSI color definitions:**
-   ```
-   RESET='\033[0m'
-   BOLD='\033[1m'
-   DIM='\033[2m'
-   WHITE='\033[37m'
-   CYAN='\033[36m'
-   BLUE='\033[34m'
-   GREEN='\033[32m'
-   RED='\033[31m'
-   YELLOW='\033[33m'
-   MAGENTA='\033[35m'
-   BG_BLUE='\033[44m'
-   ```
-
-   **State → color mapping:**
-   - "New" → `WHITE` with label `NEW`
-   - "Active" → `BLUE` with label `ACTIVE`
-   - "Resolved" → `GREEN` with label `RESOLVED`
-   - "Closed" / "Done" → `GREEN` + `BOLD` with label `DONE`
-   - "Removed" → `RED` with label `REMOVED`
-   - Any other → `YELLOW` with label in uppercase
-
-   **Output format:**
-
-   The Bash script should echo lines like this (using the ANSI variables):
-
-   ```
-   echo -e ""
-   echo -e "${BOLD}${CYAN}━━━ Sprint: {name} ━━━${RESET}"
-   echo -e "${DIM}Iteration:${RESET} {path}"
-   echo -e "${DIM}Dates:${RESET}     {startDate} → {finishDate}"
-   echo -e "${DIM}Items:${RESET}     {total count}"
-   echo -e ""
-   ```
-
-   For each top-level story/bug:
-   ```
-   echo -e "${BOLD}┌─ [{type}] #{id} -- {title}${RESET}"
-   echo -e "│  State: ${STATE_COLOR}{state}${RESET}  │  Assigned: {assignedTo or 'Unassigned'}"
-   ```
-
-   If description exists (first 3 lines):
-   ```
-   echo -e "│  ${DIM}{description line 1}${RESET}"
-   echo -e "│  ${DIM}{description line 2}${RESET}"
-   ```
-
-   If acceptance criteria exist:
-   ```
-   echo -e "│"
-   echo -e "│  ${MAGENTA}Acceptance Criteria:${RESET}"
-   echo -e "│  ${DIM}- {criterion}${RESET}"
-   ```
-
-   For each child task:
-   ```
-   echo -e "│   ${STATE_COLOR}■${RESET} #{id} -- {title}  [${STATE_COLOR}{state}${RESET}]  {assignedTo}"
-   ```
-
-   Close the story box:
-   ```
-   echo -e "└──────"
-   echo -e ""
-   ```
-
-   **Formatting rules:**
-   - **Type abbreviations:** "User Story" → "US", "Task" → "Task", "Bug" → "Bug"; all other types use the full type name.
-   - **Grouping:** items with `parentId === null` (or parentId not present in the items list) are top-level (stories/bugs). Items with a `parentId` that exists in the list are children (tasks) displayed under their parent.
-   - **Orphaned tasks:** if a child's parentId references an ID that is NOT in the sprint items list, display that child as a top-level item.
-   - **Description:** show first 3 lines only (split on newlines). If empty or null, show "(no description)" in DIM.
-   - **Acceptance Criteria:** if empty or null, show "(no acceptance criteria)" in DIM.
-   - **Dates:** parse ISO date strings and display as YYYY-MM-DD (take the first 10 characters). If null or undefined, show "not set".
-   - **Escape special chars:** when building the echo strings, escape any single quotes, double quotes, and backslashes in titles/descriptions so the Bash script doesn't break.
-
-5. **Handle edge cases:**
-   - Empty sprint (items array is []): display the sprint header, then echo "No work items in this sprint."
-   - No active sprint: the `get-sprint` command returns exit 1 with a message; display that message and stop.
+   If the user wants only their own items, use `--me`:
+   Run: `node ~/.claude/bin/azdev-tools.cjs show-sprint --me --cwd $CWD`
 </process>
 
+<important>
+Do NOT output any thinking, planning, or narration text. Just run the command and let the output speak for itself. No "Let me fetch...", "Now I'll render...", or similar messages.
+</important>
+
 <success_criteria>
-- Sprint name, iteration path, and dates are shown at the top
-- Work items are grouped by parent story with tasks indented underneath
-- State indicators use ANSI colors visible in the terminal (blue for Active, green for Resolved, etc.)
-- All output is rendered via Bash echo -e so ANSI codes are interpreted
-- No HTML tags appear in the output
-- Empty sprint and no-active-sprint states produce clear, actionable messages
+- Sprint board is displayed with a single command call
+- No intermediate steps, no JSON juggling, no dynamic script construction
+- No narration or thinking text — only the sprint board output
+- Errors produce clear, actionable messages from the helper script
 </success_criteria>


### PR DESCRIPTION
…play

Replaces the render-sprint approach (which required Claude to pass large JSON via CLI args) with show-sprint that fetches AND renders internally. The /azdev-sprint command now runs one command with zero narration.

https://claude.ai/code/session_01VnPPT3e2EzsmCfBM4JJpXU