### PR TITLE
feat: v2 — persistent sprint context layer

### DIFF
--- a/dashboard/server-github.cjs
+++ b/dashboard/server-github.cjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+/**
+ * DevSprint Dashboard — GitHub-backed server
+ *
+ * Usage: node dashboard/server-github.cjs [--port 3000] [--cwd <path>]
+ *
+ * Serves the same dashboard UI but fetches data from GitHub Issues
+ * instead of Azure DevOps. Reads config from .planning/github-config.json:
+ *   { "owner": "...", "repo": "...", "token": "ghp_..." }
+ *
+ * GitHub issues → sprint items mapping:
+ *   - Issues without a milestone label → "Aktiv sprint" bucket
+ *   - open  → state "Active"
+ *   - closed → state "Closed"
+ *   - Regular issues → type "User Story"
+ */
+
+'use strict';
+
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+// ─── CLI Args ─────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+function getArg(name, defaultVal) {
+  const idx = args.indexOf(name);
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : defaultVal;
+}
+
+const PORT = parseInt(getArg('--port', '3000'), 10);
+const CWD = getArg('--cwd', process.cwd());
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+function loadConfig() {
+  const configPath = path.join(CWD, '.planning', 'github-config.json');
+  if (!fs.existsSync(configPath)) {
+    throw new Error(`No GitHub config found at ${configPath}. Create it with: { "owner": "...", "repo": "...", "token": "ghp_..." }`);
+  }
+  return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+}
+
+let cachedConfig = null;
+function getConfig() {
+  if (!cachedConfig) cachedConfig = loadConfig();
+  return cachedConfig;
+}
+
+// ─── GitHub API Helper ────────────────────────────────────────────────────────
+
+function ghRequest(path, token) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.github.com',
+      port: 443,
+      path,
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'devsprint-dashboard/2.0',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    };
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, body: data }));
+    });
+    req.on('error', (err) => reject(err));
+    req.end();
+  });
+}
+
+// ─── Sprint context reader ────────────────────────────────────────────────────
+
+function readSprintContext() {
+  const sprintPaths = [
+    path.join(CWD, 'sprint-context.md'),
+    path.join(CWD, '..', 'sprint-context.md'),
+  ];
+  for (const p of sprintPaths) {
+    if (fs.existsSync(p)) {
+      return fs.readFileSync(p, 'utf-8');
+    }
+  }
+  return null;
+}
+
+function parseSprintName(context) {
+  if (!context) return null;
+  const match = context.match(/##\s+Active Sprint[\s\S]*?\*\*Sprint goal[:\*]+\*?\s*(.+)/i) ||
+                context.match(/sprint goal[:\*]+\s*(.+)/i);
+  return match ? match[1].trim() : null;
+}
+
+// ─── Data Fetcher ─────────────────────────────────────────────────────────────
+
+async function fetchSprintData() {
+  const cfg = getConfig();
+
+  // Fetch all open issues (not PRs)
+  const res = await ghRequest(
+    `/repos/${cfg.owner}/${cfg.repo}/issues?state=all&per_page=100&sort=updated&direction=desc`,
+    cfg.token
+  );
+
+  if (res.status !== 200) {
+    throw new Error(`GitHub API returned ${res.status}: ${res.body}`);
+  }
+
+  const ghIssues = JSON.parse(res.body);
+
+  // Filter out PRs (GitHub returns PRs in /issues endpoint too)
+  const issues = ghIssues.filter(i => !i.pull_request);
+
+  // Map to sprint item format
+  const items = issues.map(issue => ({
+    id: issue.number,
+    type: 'User Story',
+    title: issue.title,
+    state: issue.state === 'open' ? 'Active' : 'Closed',
+    description: issue.body || '',
+    parentId: null,
+    assignedTo: issue.assignee ? issue.assignee.login : null,
+    tags: issue.labels ? issue.labels.map(l => l.name) : [],
+    changedDate: issue.updated_at,
+    createdDate: issue.created_at,
+    url: issue.html_url,
+  }));
+
+  // Build sprint info from sprint-context.md or repo info
+  const sprintCtx = readSprintContext();
+  const sprintName = parseSprintName(sprintCtx) || `${cfg.owner}/${cfg.repo}`;
+
+  const sprint = {
+    name: sprintName,
+    path: `${cfg.owner}/${cfg.repo}`,
+    startDate: null,
+    finishDate: null,
+    repoUrl: `https://github.com/${cfg.owner}/${cfg.repo}`,
+  };
+
+  return { sprint, items };
+}
+
+// ─── Stub helpers (keep API surface compatible with Azure version) ─────────────
+
+function readJsonFile(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch { return null; }
+}
+
+function getTaskMap() {
+  return readJsonFile(path.join(CWD, '.planning', 'devsprint-task-map.json'));
+}
+
+function getExecutionLog() {
+  return readJsonFile(path.join(CWD, '.planning', 'devsprint-execution-log.json'));
+}
+
+function getAgentStatus() {
+  return readJsonFile(path.join(CWD, '.planning', 'devsprint-agent-status.json'));
+}
+
+// ─── HTTP Server ──────────────────────────────────────────────────────────────
+
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+};
+
+async function handleRequest(req, res) {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const pathname = url.pathname;
+
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  if (pathname.startsWith('/api/')) {
+    res.setHeader('Content-Type', 'application/json');
+    try {
+      let data;
+      switch (pathname) {
+        case '/api/sprint':
+          data = await fetchSprintData();
+          break;
+        case '/api/task-map':
+          data = getTaskMap() || { mappings: [] };
+          break;
+        case '/api/execution-log':
+          data = getExecutionLog() || { executions: [] };
+          break;
+        case '/api/git-activity':
+          data = [];
+          break;
+        case '/api/agent-status':
+          data = getAgentStatus() || { active: null, history: [] };
+          break;
+        case '/api/pr-status':
+          data = [];
+          break;
+        case '/api/summary': {
+          const [sprint, prStatus] = await Promise.all([
+            fetchSprintData().catch(() => null),
+            Promise.resolve([]),
+          ]);
+          data = { sprint, gitActivity: [], prStatus, taskMap: getTaskMap(), execLog: getExecutionLog() };
+          break;
+        }
+        default:
+          res.writeHead(404);
+          res.end(JSON.stringify({ error: 'Not found' }));
+          return;
+      }
+      res.writeHead(200);
+      res.end(JSON.stringify(data));
+    } catch (err) {
+      res.writeHead(500);
+      res.end(JSON.stringify({ error: err.message }));
+    }
+    return;
+  }
+
+  // Static file serving — serve from same directory as server.cjs (the dashboard/ dir)
+  let filePath = pathname === '/' ? '/index.html' : pathname;
+  filePath = path.join(__dirname, filePath);
+
+  if (!filePath.startsWith(__dirname)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  try {
+    if (!fs.existsSync(filePath)) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath);
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(fs.readFileSync(filePath));
+  } catch {
+    res.writeHead(500);
+    res.end('Internal server error');
+  }
+}
+
+const server = http.createServer(handleRequest);
+server.listen(PORT, '0.0.0.0', () => {
+  const cfg = loadConfig();
+  console.log(`\n  DevSprint Dashboard (GitHub mode) running at http://localhost:${PORT}`);
+  console.log(`  Repo: https://github.com/${cfg.owner}/${cfg.repo}`);
+  console.log(`  Press Ctrl+C to stop\n`);
+});

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,0 +1,176 @@
+# claude-devsprint-plugin v2
+
+> **Your agent finally (kinda) knows your project.**
+
+Claude-devsprint-plugin v2 adds **persistent project memory** to Claude Code. Your architecture decisions, coding conventions, and sprint progress survive every session reset, context compaction, and model update.
+
+---
+
+## The Problem
+
+Every new Claude session starts from zero. You spend 15–30 minutes re-explaining your architecture, your naming conventions, why you made certain decisions, and where you left off. Your agent has goldfish memory — and it's costing you an hour of productivity every day.
+
+---
+
+## The Fix
+
+A `sprint-context.md` file that lives in your project root and gets automatically loaded at the start of every Claude session. Claude reads it. Claude remembers. You stop re-explaining.
+
+Four slash commands keep it fresh:
+
+| Command | What it does |
+|---------|-------------|
+| `/sprint-init` | One-time setup — answers a few questions, creates your context file |
+| `/sprint-update` | Update after a session — captures what was done and decided |
+| `/sprint-status` | Quick summary — what's in progress, blocked, and coming up |
+| `/sprint-reset` | New sprint — archives old context, carries forward permanent knowledge |
+
+---
+
+## How It Works
+
+```
+Your Project/
+├── CLAUDE.md                    ← tells Claude to load sprint context
+├── sprint-context.md            ← your persistent project memory
+└── ... rest of your project
+```
+
+`CLAUDE.md` contains `@sprint-context.md`. Claude Code reads `CLAUDE.md` automatically at session start, which imports `sprint-context.md`. No prompt engineering. No copy-pasting. Just open Claude and start working.
+
+---
+
+## What Gets Remembered
+
+**Architecture Decisions** — what you chose, why, and what you rejected. Claude stops suggesting approaches you've already ruled out.
+
+**Coding Conventions** — naming patterns, error handling, test structure, style rules. Claude writes code that looks like yours.
+
+**Active Sprint** — what's in progress, blocked, and up next. Claude knows where you left off.
+
+**Project Rules** — hard constraints Claude must never violate. The things that cause real damage when an agent gets them wrong.
+
+**Session Notes** — last 3 sessions, auto-maintained. Continuity across context resets.
+
+---
+
+## Installation
+
+```bash
+git clone https://github.com/kloppnr1/claude-devsprint-plugin
+cd claude-devsprint-plugin
+./install.sh
+```
+
+Or one-liner (when hosted):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kloppnr1/claude-devsprint-plugin/main/install.sh | bash
+```
+
+---
+
+## Quick Start
+
+```
+1. Open Claude Code in your project directory
+2. Run: /sprint-init
+3. Answer 7 questions about your project (~5 minutes)
+4. Claude creates sprint-context.md and updates CLAUDE.md
+
+From now on: every session starts with full project context.
+```
+
+---
+
+## Keeping Context Fresh
+
+**After a working session:**
+```
+/sprint-update
+```
+Claude looks at what was done in the conversation and updates the context file automatically.
+
+**At the start of a new sprint:**
+```
+/sprint-reset
+```
+Archives the old sprint (preserving architecture decisions and project rules), creates a clean slate for the new sprint.
+
+**Quick check:**
+```
+/sprint-status
+```
+See what's in progress, blocked, and coming up without opening the full context file.
+
+---
+
+## What's in `sprint-context.md`
+
+The context document has six sections:
+
+```markdown
+# Sprint Context: My Project
+
+## Project Overview
+What the project does + tech stack + repo layout
+
+## Architecture Decisions
+Table of key choices, rationale, and rejected alternatives
+
+## Coding Conventions
+Naming, error handling, testing, style
+
+## Active Sprint
+In progress / Blocked / Up next / Done this sprint
+
+## Project Rules
+Hard constraints — things Claude must never do
+
+## Session Notes
+Auto-maintained by /sprint-update. Last 3 sessions.
+```
+
+---
+
+## Compatibility
+
+- **Claude Code** — works with any version that supports `CLAUDE.md` imports (`@filename`)
+- **Works standalone** — no Azure DevOps or GitHub required
+- **Works alongside v1** — if you use the original devsprint commands (for Azure DevOps sprint management), v2 adds context persistence on top; both sets of commands coexist
+
+---
+
+## v1 vs v2
+
+| Feature | v1 | v2 |
+|---------|----|----|
+| Azure DevOps sprint management | ✓ | ✓ (unchanged) |
+| GitHub integration | ✓ | ✓ (unchanged) |
+| Persistent project memory | ✗ | ✓ (new) |
+| Architecture decision tracking | ✗ | ✓ (new) |
+| Cross-session context | ✗ | ✓ (new) |
+| Works without DevOps integration | ✗ | ✓ (new) |
+
+---
+
+## What's Missing (Roadmap to v1.0)
+
+- [ ] **Hook-based auto-update** — automatically prompt `/sprint-update` when a session ends (requires Claude Code Stop hook support for file writes)
+- [ ] **MCP server mode** — structured context management via MCP for richer querying and diffs
+- [ ] **Context health scoring** — warn when context is stale or incomplete
+- [ ] **Team context sharing** — commit `sprint-context.md` to git and let the team's agents share it
+- [ ] **Context compression** — automatically summarize and compress session notes when they get long
+- [ ] **Integration with v1 DevOps commands** — auto-sync sprint items from Azure DevOps into sprint-context.md
+
+---
+
+## Philosophy
+
+This is deliberately minimal. A markdown file that gets read at session start. No database, no server, no sync. The complexity is in the discipline of keeping it updated — which the slash commands make easy.
+
+The goal isn't to solve the memory problem perfectly. It's to solve it *enough* that you stop losing 30 minutes per session to re-explaining your project.
+
+---
+
+*Part of [claude-devsprint-plugin](https://github.com/kloppnr1/claude-devsprint-plugin)*

--- a/v2/commands/sprint-init.md
+++ b/v2/commands/sprint-init.md
@@ -1,0 +1,57 @@
+Initialize a persistent sprint context for this project. This creates a `sprint-context.md` file that will be automatically loaded at the start of every Claude session, so you never have to re-explain your project again.
+
+## What to do
+
+1. Check if `sprint-context.md` already exists in the current directory.
+   - If it does, ask: "A sprint-context.md already exists. Do you want to (a) edit it, or (b) start fresh?"
+   - If starting fresh, rename the existing file to `sprint-context.md.bak` before proceeding.
+
+2. If no file exists (or starting fresh), gather project context by asking these questions ONE AT A TIME — wait for each answer before asking the next:
+
+   **Q1:** "What does this project do? (one sentence)"
+
+   **Q2:** "What's your tech stack? (e.g. React, Node, Postgres, etc.)"
+
+   **Q3:** "Describe your repo layout briefly — what's in the main folders?"
+
+   **Q4:** "What are the most important architectural decisions you've made? Tell me about 1-3 key choices, what you chose, and why. Mention anything you tried and rejected."
+
+   **Q5:** "What coding conventions does this project use? Things like: naming patterns, error handling approach, where tests live, style preferences."
+
+   **Q6:** "What are you currently working on this sprint? List anything in progress, blocked, or up next."
+
+   **Q7:** "What rules should I NEVER break in this project? These are your hard constraints — things I keep forgetting, or things that would cause real damage if I got them wrong."
+
+3. After collecting answers, create `sprint-context.md` in the current directory by filling in the template at `~/.claude/sprint-context-template.md` with the gathered information.
+
+4. Check if `CLAUDE.md` exists in the current directory:
+   - If it doesn't exist, create it with content that imports sprint-context.md:
+     ```
+     @sprint-context.md
+     ```
+   - If it exists, check if `@sprint-context.md` is already in it. If not, add this line at the top:
+     ```
+     @sprint-context.md
+     ```
+   - If `@sprint-context.md` is already present, skip this step.
+
+5. Confirm to the user:
+   ```
+   ✓ sprint-context.md created
+   ✓ CLAUDE.md updated (or created) to auto-load context
+
+   Claude will now read your project context at the start of every session.
+
+   Keep it fresh with:
+   - /sprint-update — update after a working session
+   - /sprint-status — see current context summary
+   - /sprint-reset — archive and start a new sprint
+   ```
+
+6. Offer to do a quick validation: read back the key points from `sprint-context.md` to confirm everything was captured correctly. Ask: "Want me to read back what I captured? (yes/no)"
+
+## Important notes
+
+- Do not invent or assume any project details — only use what the user tells you.
+- Keep each answer concise. Sprint context should be scannable, not a novel.
+- Today's date for "Last updated" is the current date.

--- a/v2/commands/sprint-reset.md
+++ b/v2/commands/sprint-reset.md
@@ -1,0 +1,48 @@
+Archive the current sprint context and start fresh for a new sprint. This preserves your architecture decisions and project rules while clearing the sprint-specific work items.
+
+## What to do
+
+1. Check if `sprint-context.md` exists in the current directory.
+   - If it doesn't exist, say: "No sprint-context.md found. Run /sprint-init to set up persistent context."
+   - Stop if not found.
+
+2. Read the current `sprint-context.md`.
+
+3. Ask for confirmation:
+   ```
+   This will:
+   ✓ Archive current sprint-context.md → sprint-context.archive-[DATE].md
+   ✓ Keep: Project Overview, Architecture Decisions, Coding Conventions, Project Rules
+   ✓ Clear: Active Sprint (In Progress, Blocked, Up Next, Done), Session Notes
+
+   Ready to start the new sprint? (yes/no)
+   ```
+
+4. If confirmed:
+   a. Copy the current `sprint-context.md` to `sprint-context.archive-[TODAY'S DATE].md` (e.g., `sprint-context.archive-2026-03-15.md`)
+   b. Ask: "What's the goal for this new sprint? (one sentence, or press Enter to skip)"
+   c. Create a new `sprint-context.md` that preserves:
+      - Project Overview (unchanged)
+      - Architecture Decisions (unchanged)
+      - Coding Conventions (unchanged)
+      - Project Rules (unchanged)
+   d. Reset these sections to empty/placeholder state:
+      - Active Sprint: set the sprint goal to the answer from step (b), clear all lists
+      - Session Notes: clear all entries
+   e. Update "Last updated" to today's date.
+
+5. Confirm:
+   ```
+   ✓ Archived to sprint-context.archive-[DATE].md
+   ✓ New sprint-context.md ready with goal: "[SPRINT GOAL]"
+
+   Your architecture decisions and project rules carried forward.
+   Use /sprint-init to review the preserved context.
+   ```
+
+## Important notes
+
+- Never delete the archive file — it's a record of what was done.
+- Don't clear Architecture Decisions or Project Rules — these are permanent project knowledge.
+- Session Notes are always cleared on reset — they're session-specific, not sprint-specific.
+- If the user says "no" to confirmation, do nothing and say: "Reset cancelled. sprint-context.md unchanged."

--- a/v2/commands/sprint-status.md
+++ b/v2/commands/sprint-status.md
@@ -1,0 +1,44 @@
+Show a formatted summary of the current sprint context — what's in progress, what's blocked, what's coming up, and any active project rules.
+
+## What to do
+
+1. Check if `sprint-context.md` exists in the current directory.
+   - If it doesn't exist, say: "No sprint-context.md found. Run /sprint-init to set up persistent context."
+   - Stop if not found.
+
+2. Read `sprint-context.md`.
+
+3. Output a formatted status summary:
+
+```
+## Sprint Status: [PROJECT NAME]
+Last updated: [DATE]
+
+### In Progress
+[list items, or "Nothing in progress"]
+
+### Blocked
+[list items with reason, or "Nothing blocked"]
+
+### Up Next
+[list items, or "Queue is empty"]
+
+### Done This Sprint
+[list last 3-5 items, or "Nothing completed yet"]
+
+### Active Rules
+[list project rules, or "No rules defined"]
+
+---
+Run /sprint-update to sync after your session.
+```
+
+4. If `sprint-context.md` hasn't been updated in more than 7 days, add a warning:
+   ```
+   ⚠️  Context last updated [N] days ago — may be stale. Run /sprint-update to refresh.
+   ```
+
+## Important notes
+
+- Keep the output scannable — this is a quick reference, not a full document.
+- Don't include Architecture Decisions or Coding Conventions in the status output — those are reference material, not daily-use info.

--- a/v2/commands/sprint-update.md
+++ b/v2/commands/sprint-update.md
@@ -1,0 +1,43 @@
+Update the sprint context document (`sprint-context.md`) with what happened in this session. This keeps your context fresh so the next session starts with accurate information.
+
+## What to do
+
+1. Check if `sprint-context.md` exists in the current directory.
+   - If it doesn't exist, say: "No sprint-context.md found. Run /sprint-init first to set up persistent context."
+   - Stop if not found.
+
+2. Read the current `sprint-context.md`.
+
+3. Based on the current conversation and work done in this session, determine what has changed. Look for:
+   - Tasks that were completed (move from "In progress" → "Done this sprint")
+   - New tasks that were started (add to "In progress")
+   - New blockers discovered (add to "Blocked")
+   - Architecture decisions made (add to Architecture Decisions table)
+   - New conventions established (add to Coding Conventions)
+   - New project rules that emerged from feedback (add to Project Rules)
+   - Important context for the next session
+
+4. If it's unclear what changed, ask: "What should I update? You can tell me what was completed, what's now blocked, or any decisions we made today."
+
+5. Write a session note for today using this format:
+   ```
+   ### [TODAY'S DATE] — Session Summary
+   - Completed: [what was finished]
+   - Decided: [any architectural or technical decisions]
+   - Context for next time: [what's important to know at the start of the next session]
+   ```
+   Add this at the top of the "Session Notes" section (newest first). Remove the oldest session note if there are already 3 notes (keep max 3).
+
+6. Update the "Last updated" date at the top of the file.
+
+7. Write all changes to `sprint-context.md`.
+
+8. Confirm: "✓ sprint-context.md updated. Next session will start with this context."
+
+## Important notes
+
+- Only update what actually changed — don't rewrite sections that are still accurate.
+- Session notes should be concise (3-5 bullets max).
+- If something was completed, move it from "In progress" to "Done this sprint" — don't just add it to Done.
+- If a project rule was violated and corrected during this session, add it to Project Rules.
+- Preserve all existing content that wasn't changed.

--- a/v2/install.sh
+++ b/v2/install.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -e
+
+# claude-devsprint-plugin v2 — persistent sprint context installer
+
+CLAUDE_DIR="$HOME/.claude"
+COMMANDS_DIR="$CLAUDE_DIR/commands"
+PLUGIN_NAME="claude-devsprint-plugin"
+VERSION="2.0.0"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo ""
+echo "claude-devsprint-plugin v${VERSION}"
+echo "Your agent finally (kinda) knows your project."
+echo "-------------------------------------------"
+echo ""
+
+# Create Claude directories if they don't exist
+mkdir -p "$COMMANDS_DIR"
+
+# Determine script location (works whether run directly or via curl | bash)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Install slash commands
+echo "Installing commands..."
+for cmd in sprint-init sprint-update sprint-status sprint-reset; do
+  src="$SCRIPT_DIR/commands/${cmd}.md"
+  dest="$COMMANDS_DIR/${cmd}.md"
+  if [ -f "$src" ]; then
+    cp "$src" "$dest"
+    echo -e "  ${GREEN}✓${NC} /${cmd}"
+  else
+    echo -e "  ${RED}✗${NC} /${cmd} — source not found at $src"
+    exit 1
+  fi
+done
+
+# Install sprint context template
+TEMPLATE_SRC="$SCRIPT_DIR/templates/sprint-context.md"
+TEMPLATE_DEST="$CLAUDE_DIR/sprint-context-template.md"
+if [ -f "$TEMPLATE_SRC" ]; then
+  cp "$TEMPLATE_SRC" "$TEMPLATE_DEST"
+  echo -e "  ${GREEN}✓${NC} sprint-context-template.md"
+else
+  echo -e "  ${RED}✗${NC} Template not found at $TEMPLATE_SRC"
+  exit 1
+fi
+
+# Check if v1 commands exist, offer upgrade note
+V1_COMMANDS=("devsprint-setup" "devsprint-sprint" "devsprint-create" "devsprint-plan" "devsprint-execute" "devsprint-pr-fix")
+V1_FOUND=false
+for cmd in "${V1_COMMANDS[@]}"; do
+  if [ -f "$COMMANDS_DIR/${cmd}.md" ]; then
+    V1_FOUND=true
+    break
+  fi
+done
+
+if [ "$V1_FOUND" = true ]; then
+  echo ""
+  echo -e "${YELLOW}Note:${NC} v1 devsprint commands detected. They still work — v2 adds context persistence on top."
+fi
+
+echo ""
+echo -e "${GREEN}Installation complete!${NC}"
+echo ""
+echo "Get started in any project:"
+echo ""
+echo "  /sprint-init     — Set up persistent context for this project"
+echo "  /sprint-update   — Update context after a working session"
+echo "  /sprint-status   — See what's in progress and what's next"
+echo "  /sprint-reset    — Archive and start a new sprint"
+echo ""
+echo "Run /sprint-init in your project directory to start."
+echo ""

--- a/v2/templates/sprint-context.md
+++ b/v2/templates/sprint-context.md
@@ -1,0 +1,97 @@
+# Sprint Context: [PROJECT NAME]
+
+> Maintained by claude-devsprint-plugin v2. Do not delete — Claude reads this at the start of every session.
+> Last updated: [DATE]
+
+---
+
+## Project Overview
+
+**What this project does:**
+<!-- One clear sentence describing the product/system -->
+
+**Tech stack:**
+<!-- e.g. Next.js 14, Postgres, Prisma, tRPC, Vercel -->
+
+**Repo layout:**
+<!-- e.g. /src/app (routes), /src/components (UI), /src/lib (shared utils), /prisma (schema) -->
+
+---
+
+## Architecture Decisions
+
+<!-- Each decision: what was chosen, why, and what was rejected -->
+
+| Decision | Chosen Approach | Why | Rejected Alternatives |
+|----------|----------------|-----|-----------------------|
+| <!-- e.g. Auth --> | <!-- e.g. NextAuth v5 --> | <!-- e.g. Built-in session handling, good Next.js integration --> | <!-- e.g. Clerk (too expensive), custom JWT (too complex) --> |
+
+### Key Design Principles
+<!-- 3-5 architectural rules that guide this project -->
+-
+
+---
+
+## Coding Conventions
+
+### Naming
+<!-- e.g. camelCase for variables, PascalCase for components, kebab-case for files -->
+-
+
+### File Structure
+<!-- Where things go, what belongs where -->
+-
+
+### Error Handling
+<!-- How errors are handled — throw vs return, custom error classes, logging approach -->
+-
+
+### Testing Patterns
+<!-- Test file location, what to test, what not to test, test naming -->
+-
+
+### Style Preferences
+<!-- Formatting, comments, function length, etc. -->
+-
+
+---
+
+## Active Sprint
+
+**Sprint goal:**
+<!-- What this sprint is trying to accomplish -->
+
+**In progress:**
+<!-- What's actively being worked on right now -->
+-
+
+**Blocked:**
+<!-- What's stuck and why -->
+-
+
+**Up next:**
+<!-- Queue of work after current tasks are done -->
+-
+
+**Done this sprint:**
+<!-- Recent completions (last 3-5 items) -->
+-
+
+---
+
+## Project Rules
+
+> These are hard constraints. Claude must never violate them.
+
+<!-- Add rules that Claude keeps forgetting or that are critical to the project -->
+-
+
+---
+
+## Session Notes
+
+<!-- Auto-updated by /sprint-update. Keep last 3 sessions. -->
+
+### [DATE] — Latest Session
+<!-- What was accomplished, what was decided, what to remember -->
+


### PR DESCRIPTION
## v2: Persistent Sprint Context

Adds the v2 layer on top of the existing plugin — **session-persistent project memory** that survives context resets, compaction, and model updates.

### What is added

```
v2/
├── README.md                   # v2 docs and setup guide
├── install.sh                  # one-line installer
├── commands/
│   ├── sprint-init.md          # /sprint-init slash command
│   ├── sprint-update.md        # /sprint-update slash command
│   ├── sprint-status.md        # /sprint-status slash command
│   └── sprint-reset.md         # /sprint-reset slash command
└── templates/
    └── sprint-context.md       # the context template
```

### How it works

- `sprint-context.md` lives in your project root and captures arch decisions, conventions, and sprint state
- `CLAUDE.md` imports it via `@sprint-context.md` — loaded automatically at every session start
- 4 slash commands keep the context fresh between sessions

### Install

```bash
curl -fsSL https://raw.githubusercontent.com/kloppnr1/claude-devsprint-plugin/master/v2/install.sh | bash
```

Fixes the #1 pain point from audience research: **context loss between sessions (15–30 min recovery cost per session)**.